### PR TITLE
Hardcoded `VAL` supply removed

### DIFF
--- a/src/val.md
+++ b/src/val.md
@@ -12,9 +12,7 @@ head:
 # VAL (≚)
 
 - VAL is a new token used to reward SORA network validators that secure the network, created by [community governance](https://medium.com/sora-xor/sora-v2-implementation-1febd3260b87); all contracts and executable code were released in a disabled form and could not be used until activation by a community member (by insertion of cryptographic proof of the referendum); now it is fully activated.
-- VAL fully diluted supply will be 100,000,000. Only 33,900,000 VAL are currently circulating and the supply is capped until SORA v2 network launch.
 - The VAL token contract is also available on [Etherscan](https://etherscan.io/token/0xe88f8313e61a97cec1871ee37fbbe2a8bf3ed1e4).
-
 - VAL has [Decreasing supply](https://medium.com/sora-xor/sora-validator-rewards-419320e22df8) over time, with tokens burned at every SORA v2 network transaction.
 - Elastic rewards to validators and stake nominators are given in VAL, as a percentage of the daily burned VAL
 - Holders receive a part of the XOR created by the token bonding curve

--- a/src/val.md
+++ b/src/val.md
@@ -12,7 +12,9 @@ head:
 # VAL (≚)
 
 - VAL is a new token used to reward SORA network validators that secure the network, created by [community governance](https://medium.com/sora-xor/sora-v2-implementation-1febd3260b87); all contracts and executable code were released in a disabled form and could not be used until activation by a community member (by insertion of cryptographic proof of the referendum); now it is fully activated.
+- VAL fully diluted supply will be 100,000,000. Only 33,900,000 VAL are currently circulating and the supply is capped until SORA v2 network launch.
 - The VAL token contract is also available on [Etherscan](https://etherscan.io/token/0xe88f8313e61a97cec1871ee37fbbe2a8bf3ed1e4).
+
 - VAL has [Decreasing supply](https://medium.com/sora-xor/sora-validator-rewards-419320e22df8) over time, with tokens burned at every SORA v2 network transaction.
 - Elastic rewards to validators and stake nominators are given in VAL, as a percentage of the daily burned VAL
 - Holders receive a part of the XOR created by the token bonding curve

--- a/src/val.md
+++ b/src/val.md
@@ -12,9 +12,8 @@ head:
 # VAL (≚)
 
 - VAL is a new token used to reward SORA network validators that secure the network, created by [community governance](https://medium.com/sora-xor/sora-v2-implementation-1febd3260b87); all contracts and executable code were released in a disabled form and could not be used until activation by a community member (by insertion of cryptographic proof of the referendum); now it is fully activated.
-- VAL fully diluted supply will be 100,000,000. Only 33,900,000 VAL are currently circulating and the supply is capped until SORA v2 network launch.
+- VAL fully diluted supply is around 100,000,000 (query `tokens.totalIssuance` to get the precise number). Current VAL circulating supply can be checked [here](https://mof.sora.org/qty/val).
 - The VAL token contract is also available on [Etherscan](https://etherscan.io/token/0xe88f8313e61a97cec1871ee37fbbe2a8bf3ed1e4).
-
 - VAL has [Decreasing supply](https://medium.com/sora-xor/sora-validator-rewards-419320e22df8) over time, with tokens burned at every SORA v2 network transaction.
 - Elastic rewards to validators and stake nominators are given in VAL, as a percentage of the daily burned VAL
 - Holders receive a part of the XOR created by the token bonding curve
@@ -27,12 +26,6 @@ VAL is the validator reward token for the SORA network, used to reward those tha
 ::: info
 [VAL tokens were formerly v1 XOR tokens](https://medium.com/sora-xor/sora-validator-rewards-419320e22df8), but were turned into VAL with new tokenomics, through [community governance](https://medium.com/sora-xor/sora-v2-implementation-1febd3260b87). VAL is a multichain token that lives on the SORA v1 network and on Ethereum, with a trustless bridge—_HASHI_—that spans the two networks.
 :::
-
-## VAL Token Supply
-
-- 100 million initial total supply and decreasing [with tokens burned](https://medium.com/@sora.xor/sora-validator-rewards-419320e22df8) (current supply [here](https://sora-qty.info))
-- VAL is a free-floating token where the price is decided by the market
-- Current VAL circulating supply can be checked [here](https://mof.sora.org/qty/val)
 
 ## VAL Token Distribution
 


### PR DESCRIPTION
The link that shows the supply dynamically can be found closer to the end of the page