### PR TITLE
Add account security to SORA Economy section

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -149,6 +149,7 @@ export default withMermaid(
               items: [
                 { text: "Overview", link: "participate" },
                 { text: "Create an Address", link: "create-an-address" },
+		{ text: "Account Security", link: "account-security" },
                 { text: "Connect Wallet", link: "polkaswap-connect-wallet" },
                 {
                   text: "Send & Receive",


### PR DESCRIPTION
Fix adding an Account Security subsection in the Build on SORA section of the wiki