### PR TITLE
Corrected the repository cloning instruction in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ To build documentation locally, follow these steps:
 1. Clone the repository:
 
     ```bash
-    https://github.com/sora-xor/sora-docs.git
+    git clone https://github.com/sora-xor/sora-docs.git
     ```
 
 2. Install the dependencies:


### PR DESCRIPTION
This pull request enhances the `CONTRIBUTING.md` file  by updating the instructions under the "Clone the repository" section. The original text only included repo-url, which could lead to confusion for users. This change adds the full git clone command for better clarity and ease of use.