### PR TITLE
docs: update substrate image version to `4.6.0`; chores

### DIFF
--- a/src/adding-tokens-to-hashi-bridge.md
+++ b/src/adding-tokens-to-hashi-bridge.md
@@ -83,7 +83,6 @@ Access https://etherscan.io/address/0x313416870a4da6f12505a550b67bb73c8e21d5d3#w
 ## Registering an ERC-20 token in Ethereum and its mapping with a SORA asset
 
 1. Get all the necessary information about the token:
-
    - Address (e.g. `0xdac17f958d2ee523a2206206994597c13d831ec7`)
    - Symbol (e.g. `USDT`)
    - Name (e.g. Tether `USD`)

--- a/src/running-a-node.md
+++ b/src/running-a-node.md
@@ -78,7 +78,7 @@ If something went wrong, please visit the [Docker documentation](https://docs.do
 
 ## Get the latest SORA Node version number
 
-Users should use version **3.2.2** for the time being. We will update this article with the latest version after every update.
+Users should use version **4.6.0** for the time being. We will update this article with the latest version after every update.
 
 You should use the latest SORA Node version in order to run a
 node. You can see the latest build number here, and find the last
@@ -95,7 +95,7 @@ Use this version number for further `docker` commands in this guide. The number 
 1. Pull the docker image from the docker repository:
 
    ```bash
-   docker pull sora2/substrate:3.2.2
+   docker pull sora2/substrate:4.6.0
    ```
 
 2. Create a folder for the node configuration:
@@ -123,7 +123,7 @@ Use this version number for further `docker` commands in this guide. The number 
 4. Run the docker image (don’t forget to insert your version below!)
 
    ```bash
-   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:3.2.2 --name sora2-node --chain main --base-path /chain --unsafe-ws-external --unsafe-rpc-external --wasm-execution compiled
+   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:4.6.0 --name sora2-node --chain main --base-path /chain --unsafe-ws-external --unsafe-rpc-external --wasm-execution compiled
    ```
 
 ### On Windows
@@ -131,7 +131,7 @@ Use this version number for further `docker` commands in this guide. The number 
 1. Pull the docker image from the docker repository:
 
    ```bash
-   docker pull sora2/substrate:3.2.2
+   docker pull sora2/substrate:4.6.0
    ```
 
 2. Create a folder for the node configuration:
@@ -151,7 +151,7 @@ Use this version number for further `docker` commands in this guide. The number 
 4. Run the docker command:
 
    ```bash
-   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v sora2-node:/chain -u 0 sora2/substrate:3.2.2 --name sora2-node --chain main --base-path /chain --unsafe-ws-external --unsafe-rpc-external --wasm-execution compiled
+   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v sora2-node:/chain -u 0 sora2/substrate:4.6.0 --name sora2-node --chain main --base-path /chain --unsafe-ws-external --unsafe-rpc-external --wasm-execution compiled
    ```
 
 5. Now you can connect to your node with [polkadot.js apps](https://polkadot.js.org/apps/#/explorer). Select Local node and click Switch.
@@ -167,7 +167,7 @@ Now your node should sync!
 1. Pull the docker image from the docker repository:
 
    ```bash
-   docker pull sora2/substrate:3.2.2
+   docker pull sora2/substrate:4.6.0
    ```
 
 2. Create a folder for the node configuration
@@ -195,7 +195,7 @@ Now your node should sync!
 4. Run the Docker command:
 
    ```
-   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:3.2.2 --name sora2-node --chain main --base-path /chain --validator --rpc-methods Unsafe --rpc-cors all --execution Wasm --wasm-execution compiled
+   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:4.6.0 --name sora2-node --chain main --base-path /chain --validator --rpc-methods Unsafe --rpc-cors all --execution Wasm --wasm-execution compiled
    ```
 
    You can add the following flag to enable [Telemetry](https://telemetry.polkadot.io/#list/SORA) for your node
@@ -207,7 +207,7 @@ Now your node should sync!
 1. Pull the docker image from the docker repository
 
    ```
-   docker pull sora2/substrate:3.2.2
+   docker pull sora2/substrate:4.6.0
    ```
 
 2. Create a folder for the node configuration
@@ -227,7 +227,7 @@ Now your node should sync!
 4. Run the Docker command
 
    ```
-   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:3.2.2 --name sora2-node --chain main --base-path /chain --validator --rpc-methods Unsafe --rpc-cors all --execution Wasm --wasm-execution compiled
+   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:4.6.0 --name sora2-node --chain main --base-path /chain --validator --rpc-methods Unsafe --rpc-cors all --execution Wasm --wasm-execution compiled
    ```
 
 ## Get session keys
@@ -345,7 +345,7 @@ You can change the name of your node by editing the parameter value of:
 1. Pull the docker image from the docker repository
 
    ```bash
-   docker pull sora2/substrate:3.2.2
+   docker pull sora2/substrate:4.6.0
    ```
 
 2. Create a folder for the node configuration
@@ -373,7 +373,7 @@ You can change the name of your node by editing the parameter value of:
 4. Run the Docker command
 
    ```bash
-   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:3.2.2 --name sora2-my-node --chain main --base-path /chain --unsafe-ws-external --pruning archive --unsafe-rpc-external --wasm-execution compiled
+   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v `pwd`:/chain sora2/substrate:4.6.0 --name sora2-my-node --chain main --base-path /chain --unsafe-ws-external --pruning archive --unsafe-rpc-external --wasm-execution compiled
    ```
 
 ### On Windows
@@ -401,7 +401,7 @@ You can change the name of your node by editing the parameter value of:
 4. Run the Docker command:
 
    ```bash
-   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v sora2-node:/chain -u 0 sora2/substrate:3.2.2 --name sora2-my-node --chain main --base-path /chain --unsafe-ws-external --pruning archive --unsafe-rpc-external --wasm-execution compiled
+   docker run --rm -p 127.0.0.1:9933:9933 -p 127.0.0.1:9944:9944 -v sora2-node:/chain -u 0 sora2/substrate:4.6.0 --name sora2-my-node --chain main --base-path /chain --unsafe-ws-external --pruning archive --unsafe-rpc-external --wasm-execution compiled
    ```
 
 The node will take some time to sync. The output in logs should look like this:


### PR DESCRIPTION
Adding extra changes from #338 as per @WRRicht3r's comment (https://github.com/sora-xor/sora-docs/pull/340#issuecomment-3158521638), but as a separate PR.